### PR TITLE
Don't start gui by default. Instead, require --gui

### DIFF
--- a/src/main/java/org/neptunepowered/vanilla/launch/server/NeptuneServerMain.java
+++ b/src/main/java/org/neptunepowered/vanilla/launch/server/NeptuneServerMain.java
@@ -37,6 +37,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
+import java.util.Arrays;
 
 public class NeptuneServerMain {
 
@@ -56,6 +57,10 @@ public class NeptuneServerMain {
     public static void main(String[] args) throws Exception {
         if (!checkMinecraft()) {
             return;
+        }
+
+        if (!Arrays.asList(args).contains("--gui")) {
+            args = join(args, "--nogui");
         }
 
         Launch.main(join(args,


### PR DESCRIPTION
Most server owners don't really want the gui to show when starting the server, so it makes sense to make this the default. Instead, when a user wants the gui, he has to add `--gui` on the command line.
